### PR TITLE
Adds support for OAuth authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ A template is provided:
   - Indicate if changes are major, minor, or patch changes.
 ```
 
+## 0.5.0.0
+
+- Adds support for OAuth authentication with a new function `sendMailWithLoginOAuthSTARTTLS`.
+
 ## 0.4.0.2
 
 - Switch to `crypton` because the `cryptonite` package is no longer maintained.

--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -18,6 +18,8 @@ module Network.Mail.SMTP
     , sendMailSTARTTLS'
     , sendMailWithLoginSTARTTLS
     , sendMailWithLoginSTARTTLS'
+    , sendMailWithLoginOAuthSTARTTLS
+    , sendMailWithLoginOAuthSTARTTLS'
     , sendMailWithSenderSTARTTLS
     , sendMailWithSenderSTARTTLS'
     , simpleMail
@@ -260,6 +262,17 @@ sendCommand (SMTPC conn _) (AUTH LOGIN username password) = do
     command = "AUTH LOGIN"
     (userB64, passB64) = encodeLogin username password
 
+sendCommand (SMTPC conn _) (AUTH LOGIN_OAUTH username token) = do
+    bsPutCrLf conn command
+    _ <- parseResponse conn
+    bsPutCrLf conn tokenB64
+    (code, msg) <- parseResponse conn
+    unless (code == 235) $ fail "authentication failed."
+    return (code, msg)
+  where
+    command = "AUTH XOAUTH2"
+    tokenB64 = encodeLoginOAuth username token
+
 sendCommand (SMTPC conn _) (AUTH at username password) = do
     bsPutCrLf conn command
     (code, msg) <- parseResponse conn
@@ -364,6 +377,14 @@ sendMailWithLoginTLS host user pass mail = connectSMTPS host >>= sendMailWithLog
 sendMailWithLoginTLS' :: HostName -> PortNumber -> UserName -> Password -> Mail -> IO ()
 sendMailWithLoginTLS' host port user pass mail = connectSMTPS' host port >>= sendMailWithLoginIntern user pass mail
 
+-- | Connect to an SMTP server, login with OAuth, send a 'Mail', disconnect. Uses STARTTLS with the default port (587).
+sendMailWithLoginOAuthSTARTTLS :: HostName -> UserName -> Token -> Mail -> IO ()
+sendMailWithLoginOAuthSTARTTLS host user token mail = connectSMTPSTARTTLS host >>= sendMailWithLoginOAuthIntern user token mail
+
+-- | Connect to an SMTP server, login with OAuth, send a 'Mail', disconnect. Uses STARTTLS.
+sendMailWithLoginOAuthSTARTTLS' :: HostName -> PortNumber -> UserName -> Token -> Mail -> IO ()
+sendMailWithLoginOAuthSTARTTLS' host port user token mail = connectSMTPSTARTTLS' host port >>= sendMailWithLoginOAuthIntern user token mail
+
 -- | Send a 'Mail' with a given sender. Uses SMTPS with its default port (465).
 sendMailWithSenderTLS :: ByteString -> HostName -> Mail -> IO ()
 sendMailWithSenderTLS sender host mail = connectSMTPS host >>= sendMailWithSenderIntern sender mail
@@ -399,6 +420,12 @@ sendMailWithSenderSTARTTLS' sender host port mail = connectSMTPSTARTTLS' host po
 sendMailWithLoginIntern :: UserName -> Password -> Mail -> SMTPConnection -> IO ()
 sendMailWithLoginIntern user pass mail con = do
   _ <- sendCommand con (AUTH LOGIN user pass)
+  renderAndSend con mail
+  closeSMTP con
+
+sendMailWithLoginOAuthIntern :: UserName -> Password -> Mail -> SMTPConnection -> IO ()
+sendMailWithLoginOAuthIntern user token mail con = do
+  _ <- sendCommand con (AUTH LOGIN_OAUTH user token)
   renderAndSend con mail
   closeSMTP con
 

--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -1,5 +1,5 @@
 name:                smtp-mail
-version:             0.4.0.2
+version:             0.5.0.0
 synopsis:            Simple email sending via SMTP
 description:         This packages provides a simple interface for mail over SMTP. Please see the README for more information.
 homepage:            http://github.com/haskell-github-trust/smtp-mail


### PR DESCRIPTION
This change adds `sendMailWithLoginOAuthSTARTTLS` to the `Network.Mail.SMTP` module. This function accepts a username and an OAuth token and encodes them with base 64 in SASL XOAUTH2 format, for SMTP OAUTH authentication.

This commit implements this feature request: https://github.com/jhickner/smtp-mail/issues/34