### PR TITLE
Remove BCC before sending mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ A template is provided:
   - Indicate if changes are major, minor, or patch changes.
 ```
 
+## 0.5.0.1
+ - [#39](https://github.com/jhickner/smtp-mail/pull/39) @spencerjanssen
+    - The `Bcc` field is stripped from the message before sending to the SMTP
+      server. This is to prevent leaking the BCC contents to recipients.
+
 ## 0.5.0.0
 
 - Adds support for OAuth authentication with a new function `sendMailWithLoginOAuthSTARTTLS`.

--- a/Network/Mail/SMTP.hs
+++ b/Network/Mail/SMTP.hs
@@ -326,11 +326,14 @@ sendRenderedMail sender receivers dat conn = do
 -- 'SMTPConnection'
 renderAndSend ::SMTPConnection -> Mail -> IO ()
 renderAndSend conn mail@Mail{..} = do
-    rendered <- lazyToStrict `fmap` renderMail' mail
+    rendered <- lazyToStrict `fmap` renderMail' (removeBcc mail)
     sendRenderedMail from to rendered conn
   where enc  = encodeUtf8 . addressEmail
         from = enc mailFrom
         to   = map enc $ mailTo ++ mailCc ++ mailBcc
+
+removeBcc :: Mail -> Mail
+removeBcc mail = mail {mailBcc = []}
 
 sendMailOnConnection :: Mail -> SMTPConnection -> IO ()
 sendMailOnConnection mail con = do
@@ -436,7 +439,7 @@ sendMailWithSenderIntern sender mail con = do
 
 renderAndSendFrom :: ByteString -> SMTPConnection -> Mail -> IO ()
 renderAndSendFrom sender conn mail@Mail{..} = do
-    rendered <- BL.toStrict `fmap` renderMail' mail
+    rendered <- BL.toStrict `fmap` renderMail' (removeBcc mail)
     sendRenderedMail sender to rendered conn
   where enc  = encodeUtf8 . addressEmail
         to   = map enc $ mailTo ++ mailCc ++ mailBcc

--- a/smtp-mail.cabal
+++ b/smtp-mail.cabal
@@ -1,5 +1,5 @@
 name:                smtp-mail
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:            Simple email sending via SMTP
 description:         This packages provides a simple interface for mail over SMTP. Please see the README for more information.
 homepage:            http://github.com/haskell-github-trust/smtp-mail


### PR DESCRIPTION
When testing with Exchange I've found that the Bcc mail header is passed on to all recipients of the email. I'm not sure whether other SMTP servers have the same issue.

The RFCs are a bit murky on this issue, but I did find some support for this approach in [RFC 2822](https://www.rfc-editor.org/rfc/rfc2822#section-3.6.3):

In the first case, when a message
containing a "Bcc:" field is prepared to be sent, the "Bcc:" line is
removed even though all of the recipients (including those specified
in the "Bcc:" field) are sent a copy of the message